### PR TITLE
Use absolute URLs to avoid issues with casting

### DIFF
--- a/chores4kids-card.js
+++ b/chores4kids-card.js
@@ -3096,7 +3096,8 @@ class Chores4KidsDevCard extends LitElement {
 				try{
 					// Cache-bust so deletions take effect immediately
 					const sep = url.includes('?') ? '&' : '?';
-					const audio = new Audio(`${url}${sep}_=${Date.now()}`);
+					const resolvedUrl = this._resolveUrl(url);
+					const audio = new Audio(`${resolvedUrl}${sep}_=${Date.now()}`);
 					audio.volume = 0.7;
 					await audio.play();
 					return; // success


### PR DESCRIPTION
_I didn't create a feature branch like I should have the first time. This is the same as #19)_

According to https://www.reddit.com/r/homeassistant/comments/tqm0k6/comment/i2ixx2d, as well as my testing, relative URLs don't work on cast (cast'd?) dashboards. The base url is actually https://cast.home-assistant.io, regardless of your home assistant URL.

This change forces the URLs to be absolute.

Fixes #17 

_Note: I used [Google Jules](https://jules.google/) to write this code since my frontend sucks. I tested it on my local cast machine and the images load and the sounds play. But I don't know if this causes issues with anything else._